### PR TITLE
fix: added chunk logic for xcp_client --upload-bin

### DIFF
--- a/tools/xcp_client/src/xcp_client/mod.rs
+++ b/tools/xcp_client/src/xcp_client/mod.rs
@@ -1902,9 +1902,18 @@ impl XcpClient {
                 debug!("  Added ExtendedLinearAddress record: 0x{:04X} (base=0x{:08X})", upper_addr, (upper_addr as u32) << 16);
             }
 
-            // Create an IHEX data record for this segment (segments are always < 64KB)
-            ihex_records.push(ihex::Record::Data { offset: lower_addr, value: data });
-            debug!("  Added Data record: offset=0x{:04X}, length={}", lower_addr, seg_length);
+            // Create IHEX data records for this calibration segments of 32 bytes (segments are always < 64KB)
+            const CHUNK_SIZE: usize = 32;
+            for (i, chunk) in data.chunks(CHUNK_SIZE).enumerate() {
+                let chunk_offset = lower_addr + (i * CHUNK_SIZE) as u16;
+
+                ihex_records.push(ihex::Record::Data {
+                    offset: chunk_offset,
+                    value: chunk.to_vec(),
+                });
+
+                debug!("  Added Data record: offset=0x{:04X}, length={}", chunk_offset, chunk.len());
+            }
         }
 
         // Add End-Of-File record


### PR DESCRIPTION
Fixes #42

Added a logic to divide in multiple chunks of 32 bytes the calibration segments.

tested with `cargo test --features=a2l_reader  -- --test-threads=1 --nocapture` and all passed.

Example output:
```
:0200000480007A
:0600000076302E302E3197
:02000004800179
:2000000000000000000000009A9999999999B93F9A9999999999C93F333333333333D33F6E
:200020009A9999999999D93F000000000000E03F333333333333E33F666666666666E63F15
:200040009A9999999999E93FCDCCCCCCCCCCEC3F000000000000F03F9A9999999999F13FF7
:20006000333333333333F33FCDCCCCCCCCCCF43F666666666666F63F000000000000F83F50
:20008000000000000000F03F9A9999999999F13F333333333333F33FCDCCCCCCCCCCF43F0A
:2000A000666666666666F63F000000000000F83F9A9999999999F93F333333333333FB3F35
:2000C000CDCCCCCCCCCCFC3F666666666666FE3F0000000000000040CDCCCCCCCCCC004032
:2000E0009A99999999990140666666666666024033333333333303400000000000000440C9
:20010000000000000000A041000048420000C84200004843000096430000C8430000FA43BE
:2001200000001644000048440000614400007A440080BB440000FA4400401C4500803B4518
:20014000000100000000000102020300000000000203000000000001010203000000000189
:200160000102030400000101020304050700010101020406080900010102040508090A0016
:200180000101030508090A0A000101030508090A0A000101030508090A0A000101030508C0
:2001A000090A0A000101030508090A0A000101030508090A0A000101030508090A0A000194
:2001C00001030508090A0A000101030508090A0A00000000000000000000000000000000C2
:2001E0000000000000000000000000000000000000000000000000000000000000000000FF
:200200000000000000000000000000000000000000000000000000000000000000000000DE
:200220000000000000000000000000000000000000000000000000000000000000000000BE
:2002400000000000000000000000000000000000000000000000000000000000000000009E
:2002600000000000000000000000000000000000000000000000000000000000000000007E
:2002800000000000000000000000000000000000000000000000000000000000000000005E
:2002A000000000000000000000000000000000000000000000000000000102030000000038
:2002C0000000803F000000400000A040000020410000A041000048420000C84200004843DE
:2002E0000000000000000000000001020400000000000002030500000000010102030600E0
:18030000000001010203040500000102030507080A00000000000000B1
:00000001FF
```